### PR TITLE
Fix Docker hub url in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ Hence, for a simplified and stricter implementation of an EV charge controller, 
 [3]: https://nodejs.org/
 [4]: https://vuejs.org
 [5]: https://getbootstrap.org
-[6]: https://hub.docker.com/repository/docker/andig/evcc
+[6]: https://hub.docker.com/r/andig/evcc


### PR DESCRIPTION
Just fix the URL to the Dockerhub page to point to the public page and not the repository page